### PR TITLE
Fix InvalidVersion error from latest setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,13 @@
+from packaging.version import parse
 from setuptools import setup, find_packages
+
 import os
 
 version = None
 with open(os.path.join('yaglm', '__init__.py'), 'r') as fid:
     for line in (line.strip() for line in fid):
         if line.startswith('__version__'):
-            version = line.split('=')[1].strip().strip('\'')
+            version = parse(line.split('=')[1].strip().strip('\''))
             break
 if version is None:
     raise RuntimeError('Could not determine version')

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,6 @@
-from packaging.version import parse
 from setuptools import setup, find_packages
 
-import os
-
-version = None
-with open(os.path.join('yaglm', '__init__.py'), 'r') as fid:
-    for line in (line.strip() for line in fid):
-        if line.startswith('__version__'):
-            version = parse(line.split('=')[1].strip().strip('\''))
-            break
-if version is None:
-    raise RuntimeError('Could not determine version')
+from yaglm import __version__ as version
 
 
 install_requires = ['numpy',
@@ -18,7 +8,6 @@ install_requires = ['numpy',
                     'scikit-learn',
                     'scipy'
                     ]
-
 
 setup(name='yaglm',
       version=version,


### PR DESCRIPTION
quick fix to avoid hitting a `packaging.version.InvalidVersion` error when installing with `setuptools>=66.0.0`, but note that "`setup.py install is deprecated. Use build and pip and other standards-based tools`" so a larger refactor is in order.